### PR TITLE
Bugfix: apt-key add fails, missing gpg-agent added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     ntpdate \
     apt-transport-https \
     gpg \
+    gpg-agent \
     ca-certificates  --no-install-recommends && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Docker build fails:

 ---> Running in 56aff1ceb054
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 19665  100 19665    0     0   116k      0 --:--:-- --:--:-- --:--:--  116k
gpg: key EE8CBC9E886DDD89: 36 signatures not checked due to missing keys
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key EE8CBC9E886DDD89: public key "deb.torproject.org archive signing key" imported
gpg: failed to start agent '/usr/bin/gpg-agent': No such file or directory
gpg: can't connect to the agent: No such file or directory
gpg: Total number processed: 1
gpg:               imported: 1
gpg: no ultimately trusted keys found
ERROR: Service 'tor' failed to build: The command '/bin/sh -c curl https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --batch --import &&     	gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add - &&     	apt-get update && 	DEBIAN_FRONTEND=noninteractive apt-get install -y tor deb.torproject.org-keyring --no-install-recommends' returned a non-zero code: 2